### PR TITLE
Changes offered on reddit, some of your todo's

### DIFF
--- a/explore-with-dmenu.sh
+++ b/explore-with-dmenu.sh
@@ -28,7 +28,7 @@ function define_standard_settings {
 }
 
 define_standard_settings
-source "${XDG_CONFIG_PATH}/.edmrc" 2>/dev/null
+source "${XDG_CONFIG_HOME:-$HOME}/.edmrc" 2>/dev/null
 
 while : ; do
     dmenu_result="$(printf '%s\n' "${choices[@]}" | dmenu -i -p "${selected_path}" -l 50 ${@})" || exit 1

--- a/explore-with-dmenu.sh
+++ b/explore-with-dmenu.sh
@@ -28,16 +28,22 @@ function define_standard_settings {
 }
 
 define_standard_settings
-source "${HOME}/.edmrc" 2>/dev/null
+source "${XDG_CONFIG_PATH}/.edmrc" 2>/dev/null
 
 while : ; do
-    dmenu_result="$(printf '%s\n' "${choices[@]}" | dmenu -i -p "$selected_path" -l 50)" || exit 1
+    dmenu_result="$(printf '%s\n' "${choices[@]}" | dmenu -i -p "${selected_path}" -l 50 ${@})" || exit 1
     if [ "$dmenu_result" = '<open terminal here>' ]; then
         eval "$open_terminal_command" "\"${selected_path}\""
         exit 0
     fi
-
-    selected_path="$(realpath "${selected_path}/${dmenu_result}")"
+    if [[ $dmenu_result =~ ^/.* ]]; then
+        selected_path="$dmenu_result"
+    elif [[ $dmenu_result =~ ^h?[ft]?tps?: ]]; then
+        eval "${open_command} \"${dmenu_result}\""
+        exit 0
+    else
+        selected_path="$(realpath "${selected_path}/${dmenu_result}")"
+    fi
     if [ -f "$selected_path" ] || [ "$dmenu_result" = '.' ]; then
         eval "${open_command} \"${selected_path}\""
         exit 0

--- a/explore-with-dmenu.sh
+++ b/explore-with-dmenu.sh
@@ -28,7 +28,7 @@ function define_standard_settings {
 }
 
 define_standard_settings
-source "${XDG_CONFIG_HOME:-$HOME}/.edmrc" 2>/dev/null
+source "${XDG_CONFIG_HOME:-$HOME/.config}/.edmrc" 2>/dev/null
 
 while : ; do
     dmenu_result="$(printf '%s\n' "${choices[@]}" | dmenu -i -p "${selected_path}" -l 50 ${@})" || exit 1


### PR DESCRIPTION
Was about to try using this myself and had a free evening. Changes:
Use $XDG_CONFIG_HOME for .edmrc location, fall back to $HOME/.config if not set.
All script arguments (`$@`) are passed to `dmenu`
Add following $dmenu_result handles:
 - a string starting with '/' is treated as an absolute path, thus previous $selected_path is not prepended to it.
 - a string starting with 'ftp:', http:' or 'https:' is handled to open_command. `xdg-open` supports these three url schemas, I know MacOS `open` can handle much more, guess you can replace the regex with `^[a-z0-9]+:/`for any url.
p.s. sorry if I spoiled the fun.